### PR TITLE
Updated object reflection to flatten the inheritence hierarchy when f…

### DIFF
--- a/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
+++ b/Jint/Runtime/Descriptors/Specialized/IndexDescriptor.cs
@@ -19,10 +19,13 @@ namespace Jint.Runtime.Descriptors.Specialized
             _item = item;
 
             // get all instance indexers with exactly 1 argument
-            var indexers = targetType.GetProperties();
+            var indexers = targetType.GetProperties(BindingFlags.FlattenHierarchy | BindingFlags.Instance | BindingFlags.Public);
 
-            // try to find first indexer having either public getter or setter with matching argument type
-            foreach (var indexer in indexers)
+			int intValue;
+			var isInt = int.TryParse(key, out intValue);
+
+			// try to find first indexer having either public getter or setter with matching argument type
+			foreach (var indexer in indexers)
             {
                 if (indexer.GetIndexParameters().Length != 1) continue;
                 if (indexer.GetGetMethod() != null || indexer.GetSetMethod() != null)
@@ -34,8 +37,9 @@ namespace Jint.Runtime.Descriptors.Specialized
                         _indexer = indexer;
                         // get contains key method to avoid index exception being thrown in dictionaries
                         _containsKey = targetType.GetMethod("ContainsKey", new Type[] { paramType });
-                        break;
 
+						if (!isInt || paramType == typeof(int))
+							break;
                     }
                 }
             }

--- a/Jint/Runtime/Interop/ObjectWrapper.cs
+++ b/Jint/Runtime/Interop/ObjectWrapper.cs
@@ -59,7 +59,7 @@ namespace Jint.Runtime.Interop
             var type = Target.GetType();
 
             // look for a property
-            var property = type.GetProperties(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
+            var property = type.GetProperties(BindingFlags.FlattenHierarchy | BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
                 .Where(p => EqualsIgnoreCasing(p.Name, propertyName))
                 .FirstOrDefault();
             if (property != null)
@@ -70,7 +70,7 @@ namespace Jint.Runtime.Interop
             }
 
             // look for a field
-            var field = type.GetFields(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
+            var field = type.GetFields(BindingFlags.FlattenHierarchy | BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
                 .Where(f => EqualsIgnoreCasing(f.Name, propertyName))
                 .FirstOrDefault();
             if (field != null)
@@ -81,7 +81,7 @@ namespace Jint.Runtime.Interop
             }
 
             // if no properties were found then look for a method 
-            var methods = type.GetMethods(BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
+            var methods = type.GetMethods(BindingFlags.FlattenHierarchy | BindingFlags.Static | BindingFlags.Instance | BindingFlags.Public)
                 .Where(m => EqualsIgnoreCasing(m.Name, propertyName))
                 .ToArray();
 
@@ -93,7 +93,7 @@ namespace Jint.Runtime.Interop
             }
 
             // if no methods are found check if target implemented indexing
-            if (type.GetProperties().Where(p => p.GetIndexParameters().Length != 0).FirstOrDefault() != null)
+            if (type.GetProperties(BindingFlags.FlattenHierarchy | BindingFlags.Instance | BindingFlags.Public).Where(p => p.GetIndexParameters().Length != 0).FirstOrDefault() != null)
             {
                 return new IndexDescriptor(Engine, propertyName, Target);
             }


### PR DESCRIPTION
…inding properties, methods, fields, and indexers. IndexDescriptor will now keep looking for an int indexer if a non-int indexor is found but the index prameter can be an integer.