### PR TITLE
Corrected logic that if object couldn't be converted to another type …

### DIFF
--- a/Jint/Properties/AssemblyInfo.cs
+++ b/Jint/Properties/AssemblyInfo.cs
@@ -3,7 +3,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Jint")]
 [assembly: AssemblyDescription("Javascript Interpreter for .NET")]
-[assembly: AssemblyVersion("2.11.58.21")]
+[assembly: AssemblyVersion("2.11.58.22")]
 [assembly: AssemblyConfiguration("")]
 [assembly: AssemblyCopyright("Copyright (c) 2013, Sebastien Ros")]
 [assembly: AssemblyProduct("Jint")]

--- a/Jint/Runtime/Interop/DefaultTypeConverter.cs
+++ b/Jint/Runtime/Interop/DefaultTypeConverter.cs
@@ -196,9 +196,12 @@ namespace Jint.Runtime.Interop
         public virtual bool TryConvert(object value, Type type, IFormatProvider formatProvider, out object converted)
         {
             bool canConvert;
-            var key = value == null ? String.Format("Null->{0}", type) : String.Format("{0}->{1}", value.GetType(), type);
+			var valueType = value == null ? null : value.GetType();
+            var key = value == null ? String.Format("Null->{0}", type) : String.Format("{0}->{1}", valueType, type);
 
-            if (!_knownConversions.TryGetValue(key, out canConvert))
+			if (valueType != null && (valueType == typeof(object) || valueType.GetElementType() == typeof(object)))
+				canConvert = true;
+			else if (!_knownConversions.TryGetValue(key, out canConvert))
             {
                 lock (_lockObject)
                 {


### PR DESCRIPTION
…once, it can never be converted (cached conversion of object to something more specific is now disabled). Updated method matching to evaluate params arguments on a method-by-method basis to prevent adjusting parameters prematurely.